### PR TITLE
Enhance Turnstile Captcha Integration

### DIFF
--- a/includes/hooks/hybula_turnstile.php
+++ b/includes/hooks/hybula_turnstile.php
@@ -16,23 +16,24 @@
 
 declare(strict_types=1);
 
+// Ensure the script is executed within the WHMCS environment, preventing direct access.
 if (!defined('WHMCS')) {
     die('This file cannot be accessed directly!');
 }
 
 // Configuration Constants
+// Define whether Turnstile is enabled, whether credits are shown, and other Turnstile settings.
 const HYBULA_TURNSTILE_ENABLED = true;
 const HYBULA_TURNSTILE_CREDITS = true;
-const HYBULA_TURNSTILE_EXCLUDE_LOGIN = true;
-const HYBULA_TURNSTILE_SITE = '';
-const HYBULA_TURNSTILE_SECRET = '';
+const HYBULA_TURNSTILE_SITE = 'YOUR_KEY';
+const HYBULA_TURNSTILE_SECRET = 'YOUR_SECRET';
 const HYBULA_TURNSTILE_THEME = 'dark';
 const HYBULA_TURNSTILE_SIZE = 'normal';
 const HYBULA_TURNSTILE_LOCATIONS = ['login', 'register', 'checkout', 'ticket', 'contact', 'passwordreset'];
 const HYBULA_TURNSTILE_ERROR = '<div class="turnstile-error" style="color: red; font-size: 14px; margin-top: 5px;">Captcha verification failed. Please try again.</div>';
 
 /**
- * Sanitize input data
+ * Sanitize input data to prevent XSS attacks.
  *
  * @param string $data
  * @return string
@@ -42,12 +43,13 @@ function sanitize_input(string $data): string {
 }
 
 /**
- * Verify Turnstile Captcha
+ * Verify Turnstile Captcha with Cloudflare API.
  *
  * @param string $response
  * @return bool
  */
 function verify_turnstile(string $response): bool {
+    // Initialize cURL to send the verification request to Cloudflare's Turnstile API.
     $curl = curl_init();
     curl_setopt_array($curl, [
         CURLOPT_URL => 'https://challenges.cloudflare.com/turnstile/v0/siteverify',
@@ -63,34 +65,53 @@ function verify_turnstile(string $response): bool {
         ]),
     ]);
 
+    // Execute the request and handle errors.
     $result = curl_exec($curl);
     $err = curl_error($curl);
     curl_close($curl);
 
+    // Log any cURL errors and return false if an error occurred.
     if ($err) {
         error_log("Turnstile verification error: $err");
         return false;
     }
 
+    // Decode the JSON response and check if the verification was successful.
     $json = json_decode($result);
     return $json && $json->success;
 }
 
-// Process Turnstile validation for specific pages
-if (!empty($_POST) && (!isset($_SESSION['uid']) && HYBULA_TURNSTILE_EXCLUDE_LOGIN)) {
+// Process Turnstile validation for specific pages.
+if (!empty($_POST)) {
+    // Get the current page name and request URI.
     $pageFile = basename($_SERVER['SCRIPT_NAME'], '.php');
     $requestUri = $_SERVER['REQUEST_URI'];
 
-    $isLoginPage = ($pageFile == 'index' && isset($_POST['username']) && isset($_POST['password']) && in_array('login', HYBULA_TURNSTILE_LOCATIONS));
+    // Determine if the current page is a login page.
+    $isLoginPage = (
+        in_array('login', HYBULA_TURNSTILE_LOCATIONS) && 
+        (
+            // Main login page detection, excluding cart.
+            ($pageFile == 'index' && isset($_POST['username']) && isset($_POST['password']) && !strpos($requestUri, '/cart')) ||
+            // Specific login form action detection, excluding cart.
+            (isset($_POST['action']) && $_POST['action'] == 'login' && !strpos($requestUri, '/cart')) ||
+            // Login URL pattern detection, excluding cart.
+            (strpos($requestUri, '/login') !== false && !strpos($requestUri, '/cart'))
+        )
+    );
+
+    // Determine if the current page is a registration, contact, ticket submission, checkout, or password reset page.
     $isRegisterPage = ($pageFile == 'register' && in_array('register', HYBULA_TURNSTILE_LOCATIONS));
     $isContactPage = ($pageFile == 'contact' && in_array('contact', HYBULA_TURNSTILE_LOCATIONS));
     $isTicketPage = ($pageFile == 'submitticket' && in_array('ticket', HYBULA_TURNSTILE_LOCATIONS));
-    $isCheckoutPage = ($pageFile == 'cart' && $_GET['a'] == 'checkout' && in_array('checkout', HYBULA_TURNSTILE_LOCATIONS));
+    $isCheckoutPage = ($pageFile == 'cart' && isset($_GET['a']) && $_GET['a'] == 'checkout' && in_array('checkout', HYBULA_TURNSTILE_LOCATIONS));
     $isPasswordResetPage = (strpos($requestUri, '/password/reset') !== false && in_array('passwordreset', HYBULA_TURNSTILE_LOCATIONS));
 
+    // If Turnstile is enabled and the page requires verification, validate the Turnstile response.
     if (($isLoginPage || $isRegisterPage || $isContactPage || $isTicketPage || $isCheckoutPage || $isPasswordResetPage) && HYBULA_TURNSTILE_ENABLED) {
         $turnstileResponse = sanitize_input($_POST['cf-turnstile-response'] ?? '');
         if (!$turnstileResponse || !verify_turnstile($turnstileResponse)) {
+            // If verification fails, set an error flag and reload the page.
             $_SESSION['turnstile_error'] = true;
             header('Location: ' . $_SERVER['REQUEST_URI']);
             exit();
@@ -99,28 +120,32 @@ if (!empty($_POST) && (!isset($_SESSION['uid']) && HYBULA_TURNSTILE_EXCLUDE_LOGI
 }
 
 /**
- * Add Turnstile Captcha to specified pages
+ * Add Turnstile Captcha to specified pages in the client area.
  *
  * @param array $vars
  * @return string
  */
 function add_turnstile_captcha(array $vars): string {
-    if (!HYBULA_TURNSTILE_ENABLED || (isset($_SESSION['uid']) && HYBULA_TURNSTILE_EXCLUDE_LOGIN)) {
+    // If Turnstile is not enabled, return an empty string.
+    if (!HYBULA_TURNSTILE_ENABLED) {
         return '';
     }
 
+    // Get the current page name and request URI.
     $pageFile = basename($_SERVER['SCRIPT_NAME'], '.php');
     $requestUri = $_SERVER['REQUEST_URI'];
 
+    // Determine if the captcha should be inserted based on the current page.
     $shouldInsertCaptcha = (
         (in_array('login', HYBULA_TURNSTILE_LOCATIONS) && $vars['pagetitle'] == $vars['LANG']['login']) ||
         (in_array('register', HYBULA_TURNSTILE_LOCATIONS) && $pageFile == 'register') ||
         (in_array('contact', HYBULA_TURNSTILE_LOCATIONS) && $pageFile == 'contact') ||
         (in_array('ticket', HYBULA_TURNSTILE_LOCATIONS) && $pageFile == 'submitticket') ||
-        (in_array('checkout', HYBULA_TURNSTILE_LOCATIONS) && $pageFile == 'cart' && $_GET['a'] == 'checkout') ||
+        (in_array('checkout', HYBULA_TURNSTILE_LOCATIONS) && $pageFile == 'cart' && isset($_GET['a']) && $_GET['a'] == 'checkout') ||
         (strpos($requestUri, '/password/reset') !== false && in_array('passwordreset', HYBULA_TURNSTILE_LOCATIONS))
     );
 
+    // If captcha should be inserted, generate the necessary HTML and JavaScript.
     if ($shouldInsertCaptcha) {
         $errorMessage = isset($_SESSION['turnstile_error']) ? HYBULA_TURNSTILE_ERROR : '';
         unset($_SESSION['turnstile_error']);
@@ -137,7 +162,9 @@ function add_turnstile_captcha(array $vars): string {
         <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>';
     }
 
+    // If no captcha should be inserted, return an empty string.
     return '';
 }
 
+// Hook into the ClientAreaFooterOutput to add the Turnstile captcha to the relevant pages.
 add_hook('ClientAreaFooterOutput', 1, 'add_turnstile_captcha');

--- a/includes/hooks/hybula_turnstile.php
+++ b/includes/hooks/hybula_turnstile.php
@@ -16,7 +16,6 @@
 
 declare(strict_types=1);
 
-// Ensure the script is executed within the WHMCS environment, preventing direct access.
 if (!defined('WHMCS')) {
     die('This file cannot be accessed directly!');
 }
@@ -32,32 +31,14 @@ const HYBULA_TURNSTILE_SIZE = 'normal';
 const HYBULA_TURNSTILE_LOCATIONS = ['login', 'register', 'checkout', 'ticket', 'contact', 'passwordreset'];
 const HYBULA_TURNSTILE_ERROR = '<div class="turnstile-error" style="color: red; font-size: 14px; margin-top: 5px;">Captcha verification failed. Please try again.</div>';
 
-/**
- * Check if the current page is in the admin area.
- *
- * @return bool
- */
 function is_admin_area(): bool {
-    $requestUri = $_SERVER['REQUEST_URI'];
-    return (strpos($requestUri, '/' . HYBULA_ADMIN_PATH . '/') !== false);
+    return (strpos($_SERVER['REQUEST_URI'], '/' . HYBULA_ADMIN_PATH . '/') !== false);
 }
 
-/**
- * Sanitize input data to prevent XSS attacks.
- *
- * @param string $data
- * @return string
- */
 function sanitize_input(string $data): string {
     return htmlspecialchars(trim($data), ENT_QUOTES, 'UTF-8');
 }
 
-/**
- * Verify Turnstile Captcha with Cloudflare API.
- *
- * @param string $response
- * @return bool
- */
 function verify_turnstile(string $response): bool {
     $curl = curl_init();
     curl_setopt_array($curl, [
@@ -87,42 +68,39 @@ function verify_turnstile(string $response): bool {
     return $json && $json->success;
 }
 
-// Process Turnstile validation for specific pages.
-if (!empty($_POST) && !is_admin_area()) {
+function should_validate_turnstile(): bool {
+    if (empty($_POST) || is_admin_area() || !HYBULA_TURNSTILE_ENABLED) {
+        return false;
+    }
+
     $pageFile = basename($_SERVER['SCRIPT_NAME'], '.php');
     $requestUri = $_SERVER['REQUEST_URI'];
 
-    $isLoginPage = (
-        in_array('login', HYBULA_TURNSTILE_LOCATIONS) && 
-        (
+    $validationConditions = [
+        'login' => in_array('login', HYBULA_TURNSTILE_LOCATIONS) && (
             ($pageFile == 'index' && isset($_POST['username']) && isset($_POST['password']) && !strpos($requestUri, '/cart')) ||
             (isset($_POST['action']) && $_POST['action'] == 'login' && !strpos($requestUri, '/cart')) ||
             (strpos($requestUri, '/login') !== false && !strpos($requestUri, '/cart'))
-        )
-    );
+        ),
+        'register' => $pageFile == 'register' && in_array('register', HYBULA_TURNSTILE_LOCATIONS),
+        'contact' => $pageFile == 'contact' && in_array('contact', HYBULA_TURNSTILE_LOCATIONS),
+        'ticket' => $pageFile == 'submitticket' && in_array('ticket', HYBULA_TURNSTILE_LOCATIONS),
+        'checkout' => $pageFile == 'cart' && isset($_GET['a']) && $_GET['a'] == 'checkout' && in_array('checkout', HYBULA_TURNSTILE_LOCATIONS),
+        'passwordreset' => strpos($requestUri, '/password/reset') !== false && in_array('passwordreset', HYBULA_TURNSTILE_LOCATIONS)
+    ];
 
-    $isRegisterPage = ($pageFile == 'register' && in_array('register', HYBULA_TURNSTILE_LOCATIONS));
-    $isContactPage = ($pageFile == 'contact' && in_array('contact', HYBULA_TURNSTILE_LOCATIONS));
-    $isTicketPage = ($pageFile == 'submitticket' && in_array('ticket', HYBULA_TURNSTILE_LOCATIONS));
-    $isCheckoutPage = ($pageFile == 'cart' && isset($_GET['a']) && $_GET['a'] == 'checkout' && in_array('checkout', HYBULA_TURNSTILE_LOCATIONS));
-    $isPasswordResetPage = (strpos($requestUri, '/password/reset') !== false && in_array('passwordreset', HYBULA_TURNSTILE_LOCATIONS));
+    return in_array(true, $validationConditions);
+}
 
-    if (($isLoginPage || $isRegisterPage || $isContactPage || $isTicketPage || $isCheckoutPage || $isPasswordResetPage) && HYBULA_TURNSTILE_ENABLED) {
-        $turnstileResponse = sanitize_input($_POST['cf-turnstile-response'] ?? '');
-        if (!$turnstileResponse || !verify_turnstile($turnstileResponse)) {
-            $_SESSION['turnstile_error'] = true;
-            header('Location: ' . $_SERVER['REQUEST_URI']);
-            exit();
-        }
+if (should_validate_turnstile()) {
+    $turnstileResponse = sanitize_input($_POST['cf-turnstile-response'] ?? '');
+    if (!$turnstileResponse || !verify_turnstile($turnstileResponse)) {
+        $_SESSION['turnstile_error'] = true;
+        header('Location: ' . $_SERVER['REQUEST_URI']);
+        exit();
     }
 }
 
-/**
- * Add Turnstile Captcha to specified pages in the client area.
- *
- * @param array $vars
- * @return string
- */
 function add_turnstile_captcha(array $vars): string {
     if (!HYBULA_TURNSTILE_ENABLED || is_admin_area()) {
         return '';
@@ -131,33 +109,36 @@ function add_turnstile_captcha(array $vars): string {
     $pageFile = basename($_SERVER['SCRIPT_NAME'], '.php');
     $requestUri = $_SERVER['REQUEST_URI'];
 
-    $shouldInsertCaptcha = (
-        (in_array('login', HYBULA_TURNSTILE_LOCATIONS) && $vars['pagetitle'] == $vars['LANG']['login']) ||
-        (in_array('register', HYBULA_TURNSTILE_LOCATIONS) && $pageFile == 'register') ||
-        (in_array('contact', HYBULA_TURNSTILE_LOCATIONS) && $pageFile == 'contact') ||
-        (in_array('ticket', HYBULA_TURNSTILE_LOCATIONS) && $pageFile == 'submitticket') ||
-        (in_array('checkout', HYBULA_TURNSTILE_LOCATIONS) && $pageFile == 'cart' && isset($_GET['a']) && $_GET['a'] == 'checkout') ||
-        (strpos($requestUri, '/password/reset') !== false && in_array('passwordreset', HYBULA_TURNSTILE_LOCATIONS))
-    );
+    $captchaConditions = [
+        in_array('login', HYBULA_TURNSTILE_LOCATIONS) && $vars['pagetitle'] == $vars['LANG']['login'],
+        in_array('register', HYBULA_TURNSTILE_LOCATIONS) && $pageFile == 'register',
+        in_array('contact', HYBULA_TURNSTILE_LOCATIONS) && $pageFile == 'contact',
+        in_array('ticket', HYBULA_TURNSTILE_LOCATIONS) && $pageFile == 'submitticket',
+        in_array('checkout', HYBULA_TURNSTILE_LOCATIONS) && $pageFile == 'cart' && isset($_GET['a']) && $_GET['a'] == 'checkout',
+        strpos($requestUri, '/password/reset') !== false && in_array('passwordreset', HYBULA_TURNSTILE_LOCATIONS)
+    ];
 
-    if ($shouldInsertCaptcha) {
+    if (in_array(true, $captchaConditions)) {
         $errorMessage = isset($_SESSION['turnstile_error']) ? HYBULA_TURNSTILE_ERROR : '';
         unset($_SESSION['turnstile_error']);
 
-        return '<script>
-            var turnstileDiv = document.createElement("div");
-            turnstileDiv.innerHTML = \'<div class="cf-turnstile" data-sitekey="'.HYBULA_TURNSTILE_SITE.'" data-callback="javascriptCallback" data-theme="'.HYBULA_TURNSTILE_THEME.'" data-size="'.HYBULA_TURNSTILE_SIZE.'"></div>'.(HYBULA_TURNSTILE_CREDITS ? '<a href="https://github.com/hybula/whmcs-turnstile" target="_blank"><small class="text-muted text-uppercase">Captcha integration by Hybula</small></a>' : '<!-- Captcha integration by Hybula (https://github.com/hybula/whmcs-turnstile) -->').'<div id="turnstile-error-message">'.$errorMessage.'</div><br>\';
-            var formElement = document.querySelector(\'input[type=submit],#login,div.text-center > button[type=submit],#openTicketSubmit\');
+        $credits = HYBULA_TURNSTILE_CREDITS
+            ? '<a href="https://github.com/hybula/whmcs-turnstile" target="_blank"><small class="text-muted text-uppercase">Captcha integration by Hybula</small></a>'
+            : '<!-- Captcha integration by Hybula (https://github.com/hybula/whmcs-turnstile) -->';
+
+        return "<script>
+            var turnstileDiv = document.createElement('div');
+            turnstileDiv.innerHTML = '<div class=\"cf-turnstile\" data-sitekey=\"" . HYBULA_TURNSTILE_SITE . "\" data-callback=\"javascriptCallback\" data-theme=\"" . HYBULA_TURNSTILE_THEME . "\" data-size=\"" . HYBULA_TURNSTILE_SIZE . "\"></div>" . $credits . "<div id=\"turnstile-error-message\">" . $errorMessage . "</div><br>';
+            var formElement = document.querySelector('input[type=submit],#login,div.text-center > button[type=submit],#openTicketSubmit');
             if (formElement) {
                 var form = formElement.parentNode;
                 form.insertBefore(turnstileDiv, formElement);
             }
         </script>
-        <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>';
+        <script src=\"https://challenges.cloudflare.com/turnstile/v0/api.js\" async defer></script>";
     }
 
     return '';
 }
 
-// Hook into the ClientAreaFooterOutput to add the Turnstile captcha to the relevant pages.
 add_hook('ClientAreaFooterOutput', 1, 'add_turnstile_captcha');

--- a/includes/hooks/hybula_turnstile.php
+++ b/includes/hooks/hybula_turnstile.php
@@ -22,15 +22,25 @@ if (!defined('WHMCS')) {
 }
 
 // Configuration Constants
-// Define whether Turnstile is enabled, whether credits are shown, and other Turnstile settings.
-const HYBULA_TURNSTILE_ENABLED = true;
-const HYBULA_TURNSTILE_CREDITS = true;
 const HYBULA_TURNSTILE_SITE = 'YOUR_KEY';
 const HYBULA_TURNSTILE_SECRET = 'YOUR_SECRET';
+const HYBULA_ADMIN_PATH = 'YOUR_ADMIN_PATH';
+const HYBULA_TURNSTILE_ENABLED = true;
+const HYBULA_TURNSTILE_CREDITS = true;
 const HYBULA_TURNSTILE_THEME = 'dark';
 const HYBULA_TURNSTILE_SIZE = 'normal';
 const HYBULA_TURNSTILE_LOCATIONS = ['login', 'register', 'checkout', 'ticket', 'contact', 'passwordreset'];
 const HYBULA_TURNSTILE_ERROR = '<div class="turnstile-error" style="color: red; font-size: 14px; margin-top: 5px;">Captcha verification failed. Please try again.</div>';
+
+/**
+ * Check if the current page is in the admin area.
+ *
+ * @return bool
+ */
+function is_admin_area(): bool {
+    $requestUri = $_SERVER['REQUEST_URI'];
+    return (strpos($requestUri, '/' . HYBULA_ADMIN_PATH . '/') !== false);
+}
 
 /**
  * Sanitize input data to prevent XSS attacks.
@@ -49,7 +59,6 @@ function sanitize_input(string $data): string {
  * @return bool
  */
 function verify_turnstile(string $response): bool {
-    // Initialize cURL to send the verification request to Cloudflare's Turnstile API.
     $curl = curl_init();
     curl_setopt_array($curl, [
         CURLOPT_URL => 'https://challenges.cloudflare.com/turnstile/v0/siteverify',
@@ -65,53 +74,42 @@ function verify_turnstile(string $response): bool {
         ]),
     ]);
 
-    // Execute the request and handle errors.
     $result = curl_exec($curl);
     $err = curl_error($curl);
     curl_close($curl);
 
-    // Log any cURL errors and return false if an error occurred.
     if ($err) {
         error_log("Turnstile verification error: $err");
         return false;
     }
 
-    // Decode the JSON response and check if the verification was successful.
     $json = json_decode($result);
     return $json && $json->success;
 }
 
 // Process Turnstile validation for specific pages.
-if (!empty($_POST)) {
-    // Get the current page name and request URI.
+if (!empty($_POST) && !is_admin_area()) {
     $pageFile = basename($_SERVER['SCRIPT_NAME'], '.php');
     $requestUri = $_SERVER['REQUEST_URI'];
 
-    // Determine if the current page is a login page.
     $isLoginPage = (
         in_array('login', HYBULA_TURNSTILE_LOCATIONS) && 
         (
-            // Main login page detection, excluding cart.
             ($pageFile == 'index' && isset($_POST['username']) && isset($_POST['password']) && !strpos($requestUri, '/cart')) ||
-            // Specific login form action detection, excluding cart.
             (isset($_POST['action']) && $_POST['action'] == 'login' && !strpos($requestUri, '/cart')) ||
-            // Login URL pattern detection, excluding cart.
             (strpos($requestUri, '/login') !== false && !strpos($requestUri, '/cart'))
         )
     );
 
-    // Determine if the current page is a registration, contact, ticket submission, checkout, or password reset page.
     $isRegisterPage = ($pageFile == 'register' && in_array('register', HYBULA_TURNSTILE_LOCATIONS));
     $isContactPage = ($pageFile == 'contact' && in_array('contact', HYBULA_TURNSTILE_LOCATIONS));
     $isTicketPage = ($pageFile == 'submitticket' && in_array('ticket', HYBULA_TURNSTILE_LOCATIONS));
     $isCheckoutPage = ($pageFile == 'cart' && isset($_GET['a']) && $_GET['a'] == 'checkout' && in_array('checkout', HYBULA_TURNSTILE_LOCATIONS));
     $isPasswordResetPage = (strpos($requestUri, '/password/reset') !== false && in_array('passwordreset', HYBULA_TURNSTILE_LOCATIONS));
 
-    // If Turnstile is enabled and the page requires verification, validate the Turnstile response.
     if (($isLoginPage || $isRegisterPage || $isContactPage || $isTicketPage || $isCheckoutPage || $isPasswordResetPage) && HYBULA_TURNSTILE_ENABLED) {
         $turnstileResponse = sanitize_input($_POST['cf-turnstile-response'] ?? '');
         if (!$turnstileResponse || !verify_turnstile($turnstileResponse)) {
-            // If verification fails, set an error flag and reload the page.
             $_SESSION['turnstile_error'] = true;
             header('Location: ' . $_SERVER['REQUEST_URI']);
             exit();
@@ -126,16 +124,13 @@ if (!empty($_POST)) {
  * @return string
  */
 function add_turnstile_captcha(array $vars): string {
-    // If Turnstile is not enabled, return an empty string.
-    if (!HYBULA_TURNSTILE_ENABLED) {
+    if (!HYBULA_TURNSTILE_ENABLED || is_admin_area()) {
         return '';
     }
 
-    // Get the current page name and request URI.
     $pageFile = basename($_SERVER['SCRIPT_NAME'], '.php');
     $requestUri = $_SERVER['REQUEST_URI'];
 
-    // Determine if the captcha should be inserted based on the current page.
     $shouldInsertCaptcha = (
         (in_array('login', HYBULA_TURNSTILE_LOCATIONS) && $vars['pagetitle'] == $vars['LANG']['login']) ||
         (in_array('register', HYBULA_TURNSTILE_LOCATIONS) && $pageFile == 'register') ||
@@ -145,14 +140,13 @@ function add_turnstile_captcha(array $vars): string {
         (strpos($requestUri, '/password/reset') !== false && in_array('passwordreset', HYBULA_TURNSTILE_LOCATIONS))
     );
 
-    // If captcha should be inserted, generate the necessary HTML and JavaScript.
     if ($shouldInsertCaptcha) {
         $errorMessage = isset($_SESSION['turnstile_error']) ? HYBULA_TURNSTILE_ERROR : '';
         unset($_SESSION['turnstile_error']);
 
         return '<script>
             var turnstileDiv = document.createElement("div");
-            turnstileDiv.innerHTML = \'<div class="cf-turnstile" data-sitekey="'.HYBULA_TURNSTILE_SITE.'" data-callback="javascriptCallback" data-theme="'.HYBULA_TURNSTILE_THEME.'" data-size="'.HYBULA_TURNSTILE_SIZE.'"></div>'.(HYBULA_TURNSTILE_CREDITS ? '' : '<!-- Captcha integration by Hybula (https://github.com/hybula/whmcs-turnstile) -->').'<div id="turnstile-error-message">'.$errorMessage.'</div><br>\';
+            turnstileDiv.innerHTML = \'<div class="cf-turnstile" data-sitekey="'.HYBULA_TURNSTILE_SITE.'" data-callback="javascriptCallback" data-theme="'.HYBULA_TURNSTILE_THEME.'" data-size="'.HYBULA_TURNSTILE_SIZE.'"></div>'.(HYBULA_TURNSTILE_CREDITS ? '<a href="https://github.com/hybula/whmcs-turnstile" target="_blank"><small class="text-muted text-uppercase">Captcha integration by Hybula</small></a>' : '<!-- Captcha integration by Hybula (https://github.com/hybula/whmcs-turnstile) -->').'<div id="turnstile-error-message">'.$errorMessage.'</div><br>\';
             var formElement = document.querySelector(\'input[type=submit],#login,div.text-center > button[type=submit],#openTicketSubmit\');
             if (formElement) {
                 var form = formElement.parentNode;
@@ -162,7 +156,6 @@ function add_turnstile_captcha(array $vars): string {
         <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>';
     }
 
-    // If no captcha should be inserted, return an empty string.
     return '';
 }
 

--- a/includes/hooks/hybula_turnstile.php
+++ b/includes/hooks/hybula_turnstile.php
@@ -6,7 +6,7 @@
  * and the Commons Clause Restriction; you may not use this file except in
  * compliance with the License.
  *
- * @category   whmcs
+ * @category   WHMCS
  * @package    whmcs-turnstile
  * @author     Hybula Development <development@hybula.com>
  * @copyright  2023 Hybula B.V.
@@ -20,65 +20,124 @@ if (!defined('WHMCS')) {
     die('This file cannot be accessed directly!');
 }
 
-if (!empty($_POST) && (!isset($_SESSION['uid']) && hybulaTurnstileExcludeLogin)) {
-    $pageFile = basename($_SERVER['SCRIPT_NAME'], '.php');
-    if ((($pageFile == 'index' && isset($_POST['username']) && isset($_POST['password']) && in_array('login', hybulaTurnstileLocations)) ||
-            ($pageFile == 'register' && in_array('register', hybulaTurnstileLocations)) ||
-            ($pageFile == 'contact' && in_array('contact', hybulaTurnstileLocations)) ||
-            ($pageFile == 'submitticket' && in_array('ticket', hybulaTurnstileLocations)) ||
-            ($pageFile == 'cart' && $_GET['a'] == 'checkout' && in_array('checkout', hybulaTurnstileLocations))) && hybulaTurnstileEnabled) {
-        if (!isset($_POST['cf-turnstile-response'])) {
-            unset($_SESSION['uid']);
-            die('Missing captcha response in POST data!');
-        }
+// Configuration Constants
+const HYBULA_TURNSTILE_ENABLED = true;
+const HYBULA_TURNSTILE_CREDITS = true;
+const HYBULA_TURNSTILE_EXCLUDE_LOGIN = true;
+const HYBULA_TURNSTILE_SITE = '';
+const HYBULA_TURNSTILE_SECRET = '';
+const HYBULA_TURNSTILE_THEME = 'dark';
+const HYBULA_TURNSTILE_SIZE = 'normal';
+const HYBULA_TURNSTILE_LOCATIONS = ['login', 'register', 'checkout', 'ticket', 'contact', 'passwordreset'];
+const HYBULA_TURNSTILE_ERROR = '<div class="turnstile-error" style="color: red; font-size: 14px; margin-top: 5px;">Captcha verification failed. Please try again.</div>';
 
-        $curl = curl_init();
-        curl_setopt_array($curl, [
-            CURLOPT_CONNECTTIMEOUT => 10,
-            CURLOPT_CUSTOMREQUEST => 'POST',
-            CURLOPT_FOLLOWLOCATION => 1,
-            CURLOPT_HTTPHEADER => [
-                'Content-Type: application/json',
-            ],
-            CURLOPT_POSTFIELDS => json_encode([
-                'secret' => hybulaTurnstileSecret,
-                'response' => $_POST['cf-turnstile-response'],
-                'remoteip' => $_SERVER['REMOTE_ADDR']
-            ]),
-            CURLOPT_RETURNTRANSFER => true,
-            CURLOPT_TIMEOUT => 30,
-            CURLOPT_URL => 'https://challenges.cloudflare.com/turnstile/v0/siteverify',
-        ]);
-        $result = curl_exec($curl);
-        $err = curl_error($curl);
-        curl_close($curl);
-        if ($json = json_decode($result)) {
-            if (!$json->success) {
-                unset($_SESSION['uid']);
-                die(hybulaTurnstileError);
-            }
+/**
+ * Sanitize input data
+ *
+ * @param string $data
+ * @return string
+ */
+function sanitize_input(string $data): string {
+    return htmlspecialchars(trim($data), ENT_QUOTES, 'UTF-8');
+}
+
+/**
+ * Verify Turnstile Captcha
+ *
+ * @param string $response
+ * @return bool
+ */
+function verify_turnstile(string $response): bool {
+    $curl = curl_init();
+    curl_setopt_array($curl, [
+        CURLOPT_URL => 'https://challenges.cloudflare.com/turnstile/v0/siteverify',
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_TIMEOUT => 30,
+        CURLOPT_CONNECTTIMEOUT => 10,
+        CURLOPT_CUSTOMREQUEST => 'POST',
+        CURLOPT_HTTPHEADER => ['Content-Type: application/json'],
+        CURLOPT_POSTFIELDS => json_encode([
+            'secret' => HYBULA_TURNSTILE_SECRET,
+            'response' => $response,
+            'remoteip' => $_SERVER['REMOTE_ADDR']
+        ]),
+    ]);
+
+    $result = curl_exec($curl);
+    $err = curl_error($curl);
+    curl_close($curl);
+
+    if ($err) {
+        error_log("Turnstile verification error: $err");
+        return false;
+    }
+
+    $json = json_decode($result);
+    return $json && $json->success;
+}
+
+// Process Turnstile validation for specific pages
+if (!empty($_POST) && (!isset($_SESSION['uid']) && HYBULA_TURNSTILE_EXCLUDE_LOGIN)) {
+    $pageFile = basename($_SERVER['SCRIPT_NAME'], '.php');
+    $requestUri = $_SERVER['REQUEST_URI'];
+
+    $isLoginPage = ($pageFile == 'index' && isset($_POST['username']) && isset($_POST['password']) && in_array('login', HYBULA_TURNSTILE_LOCATIONS));
+    $isRegisterPage = ($pageFile == 'register' && in_array('register', HYBULA_TURNSTILE_LOCATIONS));
+    $isContactPage = ($pageFile == 'contact' && in_array('contact', HYBULA_TURNSTILE_LOCATIONS));
+    $isTicketPage = ($pageFile == 'submitticket' && in_array('ticket', HYBULA_TURNSTILE_LOCATIONS));
+    $isCheckoutPage = ($pageFile == 'cart' && $_GET['a'] == 'checkout' && in_array('checkout', HYBULA_TURNSTILE_LOCATIONS));
+    $isPasswordResetPage = (strpos($requestUri, '/password/reset') !== false && in_array('passwordreset', HYBULA_TURNSTILE_LOCATIONS));
+
+    if (($isLoginPage || $isRegisterPage || $isContactPage || $isTicketPage || $isCheckoutPage || $isPasswordResetPage) && HYBULA_TURNSTILE_ENABLED) {
+        $turnstileResponse = sanitize_input($_POST['cf-turnstile-response'] ?? '');
+        if (!$turnstileResponse || !verify_turnstile($turnstileResponse)) {
+            $_SESSION['turnstile_error'] = true;
+            header('Location: ' . $_SERVER['REQUEST_URI']);
+            exit();
         }
     }
 }
 
-add_hook('ClientAreaFooterOutput', 1, function ($vars) {
-    if (!hybulaTurnstileEnabled || (isset($_SESSION['uid']) && hybulaTurnstileExcludeLogin)) {
+/**
+ * Add Turnstile Captcha to specified pages
+ *
+ * @param array $vars
+ * @return string
+ */
+function add_turnstile_captcha(array $vars): string {
+    if (!HYBULA_TURNSTILE_ENABLED || (isset($_SESSION['uid']) && HYBULA_TURNSTILE_EXCLUDE_LOGIN)) {
         return '';
     }
+
     $pageFile = basename($_SERVER['SCRIPT_NAME'], '.php');
-    if ((in_array('login', hybulaTurnstileLocations) && $vars['pagetitle'] == $vars['LANG']['login']) ||
-        (in_array('register', hybulaTurnstileLocations) && $pageFile == 'register') ||
-        (in_array('contact', hybulaTurnstileLocations) && $pageFile == 'contact') ||
-        (in_array('ticket', hybulaTurnstileLocations) && $pageFile == 'submitticket') ||
-        (in_array('checkout', hybulaTurnstileLocations) && $pageFile == 'cart' && $_GET['a'] == 'checkout')) {
+    $requestUri = $_SERVER['REQUEST_URI'];
+
+    $shouldInsertCaptcha = (
+        (in_array('login', HYBULA_TURNSTILE_LOCATIONS) && $vars['pagetitle'] == $vars['LANG']['login']) ||
+        (in_array('register', HYBULA_TURNSTILE_LOCATIONS) && $pageFile == 'register') ||
+        (in_array('contact', HYBULA_TURNSTILE_LOCATIONS) && $pageFile == 'contact') ||
+        (in_array('ticket', HYBULA_TURNSTILE_LOCATIONS) && $pageFile == 'submitticket') ||
+        (in_array('checkout', HYBULA_TURNSTILE_LOCATIONS) && $pageFile == 'cart' && $_GET['a'] == 'checkout') ||
+        (strpos($requestUri, '/password/reset') !== false && in_array('passwordreset', HYBULA_TURNSTILE_LOCATIONS))
+    );
+
+    if ($shouldInsertCaptcha) {
+        $errorMessage = isset($_SESSION['turnstile_error']) ? HYBULA_TURNSTILE_ERROR : '';
+        unset($_SESSION['turnstile_error']);
+
         return '<script>
-        var turnstileDiv = document.createElement("div");
-        turnstileDiv.innerHTML = \'<div class="cf-turnstile" data-sitekey="'.hybulaTurnstileSite.'" data-callback="javascriptCallback" data-theme="'.hybulaTurnstileTheme.'"></div>'.(hybulaTurnstileCredits ? '<a href="https://github.com/hybula/whmcs-turnstile" target="_blank"><small class="text-muted text-uppercase">Captcha integration by Hybula</small></a>' : '<!-- Captcha integration by Hybula (https://github.com/hybula/whmcs-turnstile) -->').'<br><br>\';
-        if (document.querySelector(\'input[type=submit],#login,div.text-center > button[type=submit],#openTicketSubmit\')) {
-            var form = document.querySelector(\'input[type=submit],#login,div.text-center > button[type=submit],#openTicketSubmit\').parentNode;
-            form.insertBefore(turnstileDiv, document.querySelector(\'input[type=submit],#login,div.text-center > button[type=submit],#openTicketSubmit\'));
-        }
+            var turnstileDiv = document.createElement("div");
+            turnstileDiv.innerHTML = \'<div class="cf-turnstile" data-sitekey="'.HYBULA_TURNSTILE_SITE.'" data-callback="javascriptCallback" data-theme="'.HYBULA_TURNSTILE_THEME.'" data-size="'.HYBULA_TURNSTILE_SIZE.'"></div>'.(HYBULA_TURNSTILE_CREDITS ? '' : '<!-- Captcha integration by Hybula (https://github.com/hybula/whmcs-turnstile) -->').'<div id="turnstile-error-message">'.$errorMessage.'</div><br>\';
+            var formElement = document.querySelector(\'input[type=submit],#login,div.text-center > button[type=submit],#openTicketSubmit\');
+            if (formElement) {
+                var form = formElement.parentNode;
+                form.insertBefore(turnstileDiv, formElement);
+            }
         </script>
         <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>';
     }
-});
+
+    return '';
+}
+
+add_hook('ClientAreaFooterOutput', 1, 'add_turnstile_captcha');


### PR DESCRIPTION
# Enhance Turnstile Captcha Integration

- Added configuration options for Captcha theme and size.
- Improved Captcha verification process with error logging and redirection.
- Updated error message display.
- Included new page type for password resets.
- Refactored JavaScript for better Captcha widget integration and error handling.

<img src="https://github.com/user-attachments/assets/9f156aca-dee9-4db0-b169-47bd1931a736" alt="image" width="400"/>


## Changes Overview

Updated Configuration Constants:

- Added HYBULA_TURNSTILE_SIZE: Controls the size of the Turnstile widget (e.g., normal, compact).
- Changed HYBULA_TURNSTILE_THEME: Updated from 'auto' to 'dark' to set a specific visual theme.
- Added HYBULA_TURNSTILE_LOCATIONS: Now includes a new page type for password reset.
- Updated HYBULA_TURNSTILE_ERROR: Changed error message display format to be more visible.

Refactored Captcha Verification Process:

- Added sanitize_input() Function: Ensures that input data is clean and secure.
- Added verify_turnstile() Function: Separates the Turnstile verification logic into its own function for better organization and error handling.
- Updated Captcha Validation Logic: Improved the logic to check various page types, including password reset. If Captcha verification fails, the user is redirected to the same page with an error message.

Updated Captcha Integration into Pages:

- Refactored JavaScript Code: Added error message handling directly in the script. Also, the Turnstile widget configuration is updated to include size and theme options.

## Detailed Breakdown

<b>1. Configuration Changes</b>

Constants Updated:

- HYBULA_TURNSTILE_ENABLED: Whether Turnstile is active (remains true).
- HYBULA_TURNSTILE_CREDITS: Whether to show credits for the integration (remains true).
- HYBULA_TURNSTILE_EXCLUDE_LOGIN: Whether to exclude login pages (remains true).
- HYBULA_TURNSTILE_SITE: Turnstile site key (unchanged).
- HYBULA_TURNSTILE_SECRET: Turnstile secret key (unchanged).
- HYBULA_TURNSTILE_THEME: Changed from 'auto' to 'dark' for a consistent theme.
- HYBULA_TURNSTILE_SIZE: New constant to control the size of the Turnstile widget.
- HYBULA_TURNSTILE_LOCATIONS: Added 'passwordreset' for password reset pages.
- HYBULA_TURNSTILE_ERROR: Updated error message styling to be more visible.

<b>2. Captcha Verification Enhancements</b>

- Sanitize Input: Ensures input data is safe from special characters that could be used for attacks.
- Verify Turnstile: Encapsulates the Captcha verification process in a function for clarity. Logs errors and checks the success of the Captcha verification.
- Redirection on Failure: If Captcha fails, the user is redirected back to the same page with an error message.

<b>3. Script Changes for Captcha Integration</b>

- Error Message Handling: Adds a div for error messages directly in the JavaScript code. The message is styled to stand out if verification fails.
- Dynamic Captcha Widget: Configures the Turnstile widget based on the defined theme and size. Inserts it into the form on the page if required.

